### PR TITLE
Fix IAM mapping templates and new port for probes

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ Get the Minikube IP address:
 minikube ip
 ```
 
-Open a browser to navigate to the different web applications. Use `2fa` as the username and `password` as the password to authenticate.
+Open a browser to navigate to the different web applications. Use `user` as the username and `password` as the password to authenticate.
 
 * Kibana URL: `https://<MINIKUBE_IP>/kibana`
 * Echoserver URL: `https://<MINIKUBE_IP>/echo`

--- a/example/echoserver-microgateway.yaml
+++ b/example/echoserver-microgateway.yaml
@@ -52,6 +52,8 @@ spec:
           ports:
             - name: https
               containerPort: 8443
+            - name: probes
+              containerPort: 9090
           volumeMounts:
             - name: config-files
               mountPath: /config/
@@ -59,16 +61,14 @@ spec:
             failureThreshold: 9
             timeoutSeconds: 5
             httpGet:
-              path: /healthz
-              port: https
-              scheme: HTTPS
+              path: /alive
+              port: probes
             initialDelaySeconds: 90
           readinessProbe:
             failureThreshold: 3
             httpGet:
-              path: /healthz
-              port: https
-              scheme: HTTPS
+              path: /healthy
+              port: probes
             initialDelaySeconds: 10
           lifecycle:
             preStop:

--- a/example/iam-microgateway.yaml
+++ b/example/iam-microgateway.yaml
@@ -55,6 +55,8 @@ spec:
           ports:
             - name: https
               containerPort: 8443
+            - name: probes
+              containerPort: 9090
           volumeMounts:
             - name: config-files
               mountPath: /config/
@@ -62,16 +64,14 @@ spec:
             failureThreshold: 9
             timeoutSeconds: 5
             httpGet:
-              path: /healthz
-              port: https
-              scheme: HTTPS
+              path: /alive
+              port: probes
             initialDelaySeconds: 90
           readinessProbe:
             failureThreshold: 3
             httpGet:
-              path: /healthz
-              port: https
-              scheme: HTTPS
+              path: /healthy
+              port: probes
             initialDelaySeconds: 10
           lifecycle:
             preStop:
@@ -152,12 +152,10 @@ data:
             # default redirect
             RewriteRule ^/$ https://%{ENV:HTTP_HOST_NOPORT}/auth/portal [R=303,NE]
       mappings:
-      - name: iam-loginapp
-        mapping_template_file: /config/templates/loginapp-7.3.xml
+      - mapping_template_file: /config/templates/loginapp-7.3.xml
         entry_path:
           value: /auth/
         backend_path: /auth-login/
-        session_handling: enforce_session
         operational_mode: ${OPERATIONAL_MODE:-production}
         allow_rules:
           - name: "Loginapp Single Page Application"
@@ -167,61 +165,44 @@ data:
             # TODO:
             # Not required anymore with: ALMICRO-467
             CsrfTokens.Enable    "FALSE"
-
-            RedirectForErrorPage "FALSE"
         backend:
           name: beg-iam
           hosts:
           - protocol: 'https'
             name: iam
             port: 8443
-      - name: iam-loginapp-rest-public
-        mapping_template_file: /config/templates/loginapp-7.3-REST-public.xml
+      - mapping_template_file: /config/templates/loginapp-7.3-REST-public.xml
         entry_path:
           value: /auth/rest/public
         backend_path: /auth-login/rest/public
-        session_handling: enforce_session
+        operational_mode: ${OPERATIONAL_MODE:-production}
         api_security:
           openapi:
             spec_file: /config/templates/login-rest-openapi.json
-        operational_mode: ${OPERATIONAL_MODE:-production}
-        expert_settings:
-          security_gate: |
-            RedirectForErrorPage "FALSE"
         backend:
           name: beg-iam
           hosts:
           - protocol: 'https'
             name: iam
             port: 8443
-      - name: iam-loginapp-rest-protected
-        mapping_template_file: /config/templates/loginapp-7.3-REST-protected.xml
+      - mapping_template_file: /config/templates/loginapp-7.3-REST-protected.xml
         entry_path:
           value: /auth/rest/protected
         backend_path: /auth-login/rest/protected
-        session_handling: enforce_session
         api_security:
           openapi:
             spec_file: /config/templates/login-rest-openapi.json
         operational_mode: ${OPERATIONAL_MODE:-production}
-        expert_settings:
-          security_gate: |
-            RedirectForErrorPage "FALSE"
         backend:
           name: beg-iam
           hosts:
           - protocol: 'https'
             name: iam
             port: 8443
-      - name: admin
-        mapping_template_file: /config/templates/adminapp-7.3.xml
+      - mapping_template_file: /config/templates/adminapp-7.3.xml
         entry_path:
           value: /auth-admin/
-        session_handling: enforce_session
         operational_mode: ${OPERATIONAL_MODE:-production}
-        expert_settings:
-          security_gate: |
-            RedirectForErrorPage "FALSE"
         backend:
           name: beg-iam
           hosts:

--- a/example/kibana-microgateway.yaml
+++ b/example/kibana-microgateway.yaml
@@ -52,6 +52,8 @@ spec:
           ports:
             - name: https
               containerPort: 8443
+            - name: probes
+              containerPort: 9090
           volumeMounts:
             - name: config-files
               mountPath: /config/
@@ -59,16 +61,14 @@ spec:
             failureThreshold: 9
             timeoutSeconds: 5
             httpGet:
-              path: /healthz
-              port: https
-              scheme: HTTPS
+              path: /alive
+              port: probes
             initialDelaySeconds: 90
           readinessProbe:
             failureThreshold: 3
             httpGet:
-              path: /healthz
-              port: https
-              scheme: HTTPS
+              path: /healthy
+              port: probes
             initialDelaySeconds: 10
           lifecycle:
             preStop:


### PR DESCRIPTION
* IAM mappings rely on the mapping name of other mappings. Otherwise rewrites are not done correctly.
* Microgateway deployment adapted for the new port for the probes