### PR TITLE
CHG: Redis changed to the same configuration as used in Helm Chart.

### DIFF
--- a/example/grafana-microgateway.yaml
+++ b/example/grafana-microgateway.yaml
@@ -122,8 +122,7 @@ data:
       level: info
 
     session:
-      redis_hosts:
-        - 'redis:6379'
+      redis_hosts: [ redis-master ]
       encryption_passphrase_file: /secret/config/passphrase
 
     expert_settings:

--- a/example/iam-microgateway.yaml
+++ b/example/iam-microgateway.yaml
@@ -133,8 +133,7 @@ data:
       level: info
 
     session:
-      redis_hosts:
-        - 'redis:6379'
+      redis_hosts: [ redis-master ]
       encryption_passphrase_file: /secret/config/passphrase
 
     expert_settings:

--- a/example/kibana-microgateway.yaml
+++ b/example/kibana-microgateway.yaml
@@ -122,8 +122,7 @@ data:
       level: info
 
     session:
-      redis_hosts:
-        - 'redis:6379'
+      redis_hosts: [ redis-master ]
       encryption_passphrase_file: /secret/config/passphrase
 
     expert_settings:

--- a/example/redis.yaml
+++ b/example/redis.yaml
@@ -1,45 +1,215 @@
 ---
 apiVersion: apps/v1
-kind: Deployment
+kind: StatefulSet
 metadata:
-  name: redis
+  name: redis-master
   labels:
     app: redis
 spec:
-  replicas: 1
   selector:
     matchLabels:
       app: redis
+      role: master
+  serviceName: redis-headless
   template:
     metadata:
       labels:
         app: redis
+        role: master
     spec:
       containers:
         - name: redis
-          image: redis:5.0.8
+          image: docker.io/bitnami/redis:5.0.9-debian-10-r4
           imagePullPolicy: IfNotPresent
+          command:
+            - /bin/bash
+            - -c
+            - |
+              if [[ -n $REDIS_PASSWORD_FILE ]]; then
+                password_aux=`cat ${REDIS_PASSWORD_FILE}`
+                export REDIS_PASSWORD=$password_aux
+              fi
+              if [[ ! -f /opt/bitnami/redis/etc/master.conf ]];then
+                cp /opt/bitnami/redis/mounted-etc/master.conf /opt/bitnami/redis/etc/master.conf
+              fi
+              if [[ ! -f /opt/bitnami/redis/etc/redis.conf ]];then
+                cp /opt/bitnami/redis/mounted-etc/redis.conf /opt/bitnami/redis/etc/redis.conf
+              fi
+              ARGS=("--port" "${REDIS_PORT}")
+              ARGS+=("--protected-mode" "no")
+              ARGS+=("--include" "/opt/bitnami/redis/etc/redis.conf")
+              ARGS+=("--include" "/opt/bitnami/redis/etc/master.conf")
+              /run.sh ${ARGS[@]}
           env:
-            - name: TZ
-              valueFrom:
-                configMapKeyRef:
-                  name: generic-parameters
-                  key: TZ
             - name: REDIS_REPLICATION_MODE
               value: master
+            - name: ALLOW_EMPTY_PASSWORD
+              value: "yes"
+            - name: REDIS_PORT
+              value: "6379"
           ports:
-            - containerPort: 6379
-      restartPolicy: Always
+            - name: redis
+              containerPort: 6379
+          volumeMounts:
+            - name: health
+              mountPath: /health
+            - name: redis-data
+              mountPath: /data
+              subPath:
+            - name: config
+              mountPath: /opt/bitnami/redis/mounted-etc
+            - name: redis-tmp-conf
+              mountPath: /opt/bitnami/redis/etc/
+          livenessProbe:
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 5
+            successThreshold: 1
+            failureThreshold: 5
+            exec:
+              command:
+                - sh
+                - -c
+                - /health/ping_liveness_local.sh 5
+          readinessProbe:
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 5
+            exec:
+              command:
+                - sh
+                - -c
+                - /health/ping_readiness_local.sh 5
+      volumes:
+        - name: health
+          configMap:
+            name: redis-health
+            defaultMode: 0755
+        - name: config
+          configMap:
+            name: redis
+        - name: redis-data
+          emptyDir: {}
+        - name: redis-tmp-conf
+          emptyDir: {}
 ---
 apiVersion: v1
 kind: Service
 metadata:
-  name: redis
+  name: redis-headless
   labels:
     app: redis
 spec:
+  ports:
+    - name: redis
+      port: 6379
+      targetPort: redis
   selector:
     app: redis
+  clusterIP: None
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis-master
+  labels:
+    app: redis
+spec:
   ports:
-    - name: redis-6379
+    - name: redis
       port: 6379
+      targetPort: redis
+  selector:
+    app: redis
+    role: master
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: redis
+data:
+  redis.conf: |-
+    # User-supplied configuration:
+    # Enable AOF https://redis.io/topics/persistence#append-only-file
+    appendonly yes
+    # Disable RDB persistence, AOF persistence already enabled.
+    save ""
+  master.conf: |-
+    dir /data
+  replica.conf: |-
+    dir /data
+    slave-read-only yes
+    rename-command FLUSHDB ""
+    rename-command FLUSHALL ""
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: redis-health
+data:
+  ping_readiness_local.sh: |-
+    #!/bin/bash
+    response=$(
+      timeout -s 3 $1 \
+      redis-cli \
+        -h localhost \
+        -p $REDIS_PORT \
+        ping
+    )
+    if [ "$response" != "PONG" ]; then
+      echo "$response"
+      exit 1
+    fi
+  ping_liveness_local.sh: |-
+    #!/bin/bash
+    response=$(
+      timeout -s 3 $1 \
+      redis-cli \
+        -h localhost \
+        -p $REDIS_PORT \
+        ping
+    )
+    if [ "$response" != "PONG" ] && [ "$response" != "LOADING Redis is loading the dataset in memory" ]; then
+      echo "$response"
+      exit 1
+    fi
+  ping_readiness_master.sh: |-
+    #!/bin/bash
+     response=$(
+      timeout -s 3 $1 \
+      redis-cli \
+        -h $REDIS_MASTER_HOST \
+        -p $REDIS_MASTER_PORT_NUMBER \
+        ping
+    )
+    if [ "$response" != "PONG" ]; then
+      echo "$response"
+      exit 1
+    fi
+  ping_liveness_master.sh: |-
+    #!/bin/bash
+    response=$(
+      timeout -s 3 $1 \
+      redis-cli \
+        -h $REDIS_MASTER_HOST \
+        -p $REDIS_MASTER_PORT_NUMBER \
+        ping
+    )
+    if [ "$response" != "PONG" ] && [ "$response" != "LOADING Redis is loading the dataset in memory" ]; then
+      echo "$response"
+      exit 1
+    fi
+  ping_readiness_local_and_master.sh: |-
+    script_dir="$(dirname "$0")"
+    exit_status=0
+    "$script_dir/ping_readiness_local.sh" $1 || exit_status=$?
+    "$script_dir/ping_readiness_master.sh" $1 || exit_status=$?
+    exit $exit_status
+  ping_liveness_local_and_master.sh: |-
+    script_dir="$(dirname "$0")"
+    exit_status=0
+    "$script_dir/ping_liveness_local.sh" $1 || exit_status=$?
+    "$script_dir/ping_liveness_master.sh" $1 || exit_status=$?
+    exit $exit_status


### PR DESCRIPTION
The Redis deployment was different to the one in the Helm Chart. With this PR Redis should be deployed identically as with the Helm Chart.

To generate the Kubernetes YAML files simply use the commands below:

helm repo add airlock https://ergon.github.io/airlock-helm-charts/
helm repo update
helm template mgw airlock/microgateway --set redis.enabled=true