### PR TITLE
Threat handling "block" for echoserver-microgateway

### DIFF
--- a/example/echoserver-microgateway.yaml
+++ b/example/echoserver-microgateway.yaml
@@ -164,7 +164,7 @@ data:
               value: /echo/
             session_handling: ignore_session
             operational_mode: ${OPERATIONAL_MODE:-production}
-            threat_handling: notify
+            threat_handling: block
             deny_rule_groups:
               - level: strict
             auth:


### PR DESCRIPTION
For and testing demo purpose it could be a better default to have threat handling "block" for echoserver-microgateway.