### PR TITLE
Update Readme for community edition

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,12 @@ The different components in the example are described below:
 *Airlock* is a registered trademark of [Ergon]. Ergon is a Swiss leader in leveraging digitalisation to create unique and effective client benefits, from conception to market, the result of which is
 the international distribution of globally revered products.
 
+## Disclaimer
+
+Airlock Microgateway is available as community and premium edition. The differences between these two editions are documented [here](https://docs.airlock.com/microgateway/latest/?topic=MGW-00000056).
+The Airlock Minikube Example has been designed for the premium edition and requires Airlock IAM. Nevertheless, the example might be also useful for the community edition but 
+definitely does not unleash the whole power of the Airlock suite. Because it is designed for the premium edition, all instructions are laied-out for this edition.
+
 ## Prerequisites
 
 * Install [Minikube].<br>
@@ -36,14 +42,18 @@ the international distribution of globally revered products.
 
   :warning: Using different versions may cause problems.
 * Install [kubectl].
-* A Docker Hub account with access to the private repositories:
+* Access to the public repositories:
+    * `hub.docker.com/r/ergon/airlock-microgateway-configbuilder`
     * `hub.docker.com/r/ergon/airlock-microgateway`
+    :exclamation: The Microgateway repositories are public, but Docker has [rate limits](https://www.docker.com/increase-rate-limits) for anonymous users in place. Therefore, it is recommended to use an Docker Hub account to pull the image.
+* A Docker Hub account with access to the private repository:
     * `hub.docker.com/r/ergon/airlock-iam`  
       :exclamation: Please contact `order@airlock.com` to get access to the private repositories.
 * Airlock license files:
     * A valid license for Airlock Microgateway
+      :exclamation: Without a valide license, Airlock Microgateway works as community edition with [limited functionality](https://docs.airlock.com/microgateway/latest/?topic=MGW-00000056). The example is designed for the premium edition.
     * A valid license for Airlock IAM  
-      :exclamation: Airlock Microgateway and Airlock IAM do not work without a valid license. Please contact `order@airlock.com` to get temporary Airlock license files.
+      :exclamation: Airlock IAM do not work without a valid license. Please contact `order@airlock.com` to get temporary Airlock license files.
 
 ## Start Minikube
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ definitely does not unleash the whole power of the Airlock suite. Because it is 
 * Access to the public repositories:
     * `hub.docker.com/r/ergon/airlock-microgateway-configbuilder`
     * `hub.docker.com/r/ergon/airlock-microgateway`
-    :exclamation: The Microgateway repositories are public, but Docker has [rate limits](https://www.docker.com/increase-rate-limits) for anonymous users in place. Therefore, it is recommended to use an Docker Hub account to pull the image.
+    :exclamation: The Microgateway repositories are public, but Docker has [rate limits](https://www.docker.com/increase-rate-limits) for anonymous users in place. Therefore, it is recommended to use a Docker Hub account to pull the image.
 * A Docker Hub account with access to the private repository:
     * `hub.docker.com/r/ergon/airlock-iam`  
       :exclamation: Please contact `order@airlock.com` to get access to the private repositories.
@@ -53,7 +53,7 @@ definitely does not unleash the whole power of the Airlock suite. Because it is 
     * A valid license for Airlock Microgateway
       :exclamation: Without a valide license, Airlock Microgateway works as community edition with [limited functionality](https://docs.airlock.com/microgateway/latest/?topic=MGW-00000056). The example is designed for the premium edition.
     * A valid license for Airlock IAM  
-      :exclamation: Airlock IAM do not work without a valid license. Please contact `order@airlock.com` to get temporary Airlock license files.
+      :exclamation: Airlock IAM does not work without a valid license. Please contact `order@airlock.com` to get temporary Airlock license files.
 
 ## Start Minikube
 


### PR DESCRIPTION
Airlock Microgateway 2.1 will be publicly available as community
edition. Therefore, the Docker Hub repo is public and without a
valid license the Airlock Microgateway works as community edition.
For further information consult the documentation:
https://docs.airlock.com/microgateway/latest/

Since the Airlock Minikube Example is designed for the premium
edition, the Readme has been updated to reflect that.