### PR TITLE
Fix missing Bitnami Helm chart

### DIFF
--- a/apps/authentication/templates/mariadb.yaml
+++ b/apps/authentication/templates/mariadb.yaml
@@ -12,7 +12,7 @@ spec:
   project: default
   source:
     repoURL: https://charts.bitnami.com/bitnami
-    targetRevision: 9.4.3
+    targetRevision: 11.1.7
     chart: mariadb
 
     helm:

--- a/apps/authentication/templates/microgateway.yaml
+++ b/apps/authentication/templates/microgateway.yaml
@@ -10,13 +10,13 @@ spec:
   project: default
   source:
     repoURL: https://ergon.github.io/airlock-helm-charts
-    targetRevision: 3.0.8
+    targetRevision: 3.0.15
     chart: microgateway
 
     helm:
       values: |
         image:
-          tag: "3.1"
+          tag: "3.2"
 
         fullnameOverride: iam-microgateway
 

--- a/apps/backend/templates/microgateway.yaml
+++ b/apps/backend/templates/microgateway.yaml
@@ -10,13 +10,13 @@ spec:
   project: default
   source:
     repoURL: https://ergon.github.io/airlock-helm-charts
-    targetRevision: 3.0.8
+    targetRevision: 3.0.15
     chart: microgateway
 
     helm:
       values: |
         image:
-          tag: "3.1"
+          tag: "3.2"
 
         fullnameOverride: echoserver-microgateway
 

--- a/apps/logging/templates/fluentd.yaml
+++ b/apps/logging/templates/fluentd.yaml
@@ -12,7 +12,7 @@ spec:
   project: default
   source:
     repoURL: https://charts.bitnami.com/bitnami
-    targetRevision: 5.0.10
+    targetRevision: 5.0.6
     chart: fluentd
 
     helm:

--- a/apps/logging/templates/fluentd.yaml
+++ b/apps/logging/templates/fluentd.yaml
@@ -12,7 +12,7 @@ spec:
   project: default
   source:
     repoURL: https://charts.bitnami.com/bitnami
-    targetRevision: 4.5.0
+    targetRevision: 5.0.0
     chart: fluentd
 
     helm:

--- a/apps/logging/templates/fluentd.yaml
+++ b/apps/logging/templates/fluentd.yaml
@@ -12,7 +12,7 @@ spec:
   project: default
   source:
     repoURL: https://charts.bitnami.com/bitnami
-    targetRevision: 4.1.3
+    targetRevision: 5.3.3
     chart: fluentd
 
     helm:

--- a/apps/logging/templates/fluentd.yaml
+++ b/apps/logging/templates/fluentd.yaml
@@ -12,7 +12,7 @@ spec:
   project: default
   source:
     repoURL: https://charts.bitnami.com/bitnami
-    targetRevision: 5.1.11
+    targetRevision: 4.5.0
     chart: fluentd
 
     helm:

--- a/apps/logging/templates/fluentd.yaml
+++ b/apps/logging/templates/fluentd.yaml
@@ -12,7 +12,7 @@ spec:
   project: default
   source:
     repoURL: https://charts.bitnami.com/bitnami
-    targetRevision: 5.0.21
+    targetRevision: 5.0.10
     chart: fluentd
 
     helm:

--- a/apps/logging/templates/fluentd.yaml
+++ b/apps/logging/templates/fluentd.yaml
@@ -12,7 +12,7 @@ spec:
   project: default
   source:
     repoURL: https://charts.bitnami.com/bitnami
-    targetRevision: 5.0.6
+    targetRevision: 5.0.3
     chart: fluentd
 
     helm:

--- a/apps/logging/templates/fluentd.yaml
+++ b/apps/logging/templates/fluentd.yaml
@@ -12,7 +12,7 @@ spec:
   project: default
   source:
     repoURL: https://charts.bitnami.com/bitnami
-    targetRevision: 5.0.0
+    targetRevision: 5.0.21
     chart: fluentd
 
     helm:

--- a/apps/logging/templates/fluentd.yaml
+++ b/apps/logging/templates/fluentd.yaml
@@ -12,7 +12,7 @@ spec:
   project: default
   source:
     repoURL: https://charts.bitnami.com/bitnami
-    targetRevision: 5.0.3
+    targetRevision: 5.0.2
     chart: fluentd
 
     helm:

--- a/apps/logging/templates/fluentd.yaml
+++ b/apps/logging/templates/fluentd.yaml
@@ -12,7 +12,7 @@ spec:
   project: default
   source:
     repoURL: https://charts.bitnami.com/bitnami
-    targetRevision: 4.5.0
+    targetRevision: 5.1.11
     chart: fluentd
 
     helm:

--- a/apps/logging/templates/fluentd.yaml
+++ b/apps/logging/templates/fluentd.yaml
@@ -12,7 +12,7 @@ spec:
   project: default
   source:
     repoURL: https://charts.bitnami.com/bitnami
-    targetRevision: 5.3.3
+    targetRevision: 4.5.0
     chart: fluentd
 
     helm:

--- a/apps/logging/templates/microgateway.yaml
+++ b/apps/logging/templates/microgateway.yaml
@@ -10,13 +10,13 @@ spec:
   project: default
   source:
     repoURL: https://ergon.github.io/airlock-helm-charts
-    targetRevision: 3.0.8
+    targetRevision: 3.0.15
     chart: microgateway
 
     helm:
       values: |
         image:
-          tag: "3.1"
+          tag: "3.2"
 
         fullnameOverride: kibana-microgateway
 

--- a/apps/minikube-example/templates/redis.yaml
+++ b/apps/minikube-example/templates/redis.yaml
@@ -13,20 +13,28 @@ spec:
   project: default
   source:
     repoURL: https://charts.bitnami.com/bitnami
-    targetRevision: 10.6.12
+    targetRevision: 15.7.6
     chart: redis
 
     helm:
       values: |
         fullnameOverride: redis
-        securityContext:
+        architecture: standalone
+        auth:
           enabled: false
-        cluster:
-          enabled: false
-        usePassword: false
         master:
+          containerSecurityContext:
+            enabled: false
           disableCommands: []
+          # do not disable any commands since Microgateway needs full control
+          # to configure the redis session store.
           persistence:
+            enabled: false
+        replica:
+          containerSecurityContext:
+            enabled: false
+        metrics:
+          containerSecurityContext:
             enabled: false
 
   destination:

--- a/apps/monitoring/templates/microgateway.yaml
+++ b/apps/monitoring/templates/microgateway.yaml
@@ -10,13 +10,13 @@ spec:
   project: default
   source:
     repoURL: https://ergon.github.io/airlock-helm-charts
-    targetRevision: 3.0.8
+    targetRevision: 3.0.15
     chart: microgateway
 
     helm:
       values: |
         image:
-          tag: "3.1"
+          tag: "3.2"
 
         fullnameOverride: grafana-microgateway
 


### PR DESCRIPTION
The following Helm charts have been deleted by Bitnami and are used within this example:
* redis chart 10.6.12
* mariadb chart 9.4.3
* fluentd chart 4.1.3

Because of that, the example does not start.